### PR TITLE
Specify building Setup.hs with Cabal and not local etlas-cabal

### DIFF
--- a/etlas-cabal/Setup.hs
+++ b/etlas-cabal/Setup.hs
@@ -1,0 +1,3 @@
+{-# LANGUAGE PackageImports #-}
+import "Cabal" Distribution.Simple
+main = defaultMain

--- a/etlas/Setup.hs
+++ b/etlas/Setup.hs
@@ -1,25 +1,26 @@
-import Distribution.PackageDescription ( PackageDescription )
-import Distribution.Simple ( defaultMainWithHooks
-                           , simpleUserHooks
-                           , postBuild
-                           , postCopy
-                           , postInst
-                           )
-import Distribution.Simple.InstallDirs ( mandir
-                                       , CopyDest (NoCopyDest)
-                                       )
-import Distribution.Simple.LocalBuildInfo ( LocalBuildInfo(..)
-                                          , absoluteInstallDirs
-                                          )
-import Distribution.Simple.Utils ( installOrdinaryFiles
-                                 , notice )
-import Distribution.Simple.Setup ( buildVerbosity
-                                 , copyDest
-                                 , copyVerbosity
-                                 , fromFlag
-                                 , installVerbosity
-                                 )
-import Distribution.Verbosity ( Verbosity )
+{-# LANGUAGE PackageImports #-}
+import "Cabal" Distribution.PackageDescription ( PackageDescription )
+import "Cabal" Distribution.Simple ( defaultMainWithHooks
+                                   , simpleUserHooks
+                                   , postBuild
+                                   , postCopy
+                                   , postInst
+                                   )
+import "Cabal" Distribution.Simple.InstallDirs ( mandir
+                                               , CopyDest (NoCopyDest)
+                                               )
+import "Cabal" Distribution.Simple.LocalBuildInfo ( LocalBuildInfo(..)
+                                                  , absoluteInstallDirs
+                                                  )
+import "Cabal" Distribution.Simple.Utils ( installOrdinaryFiles
+                                         , notice )
+import "Cabal" Distribution.Simple.Setup ( buildVerbosity
+                                         , copyDest
+                                         , copyVerbosity
+                                         , fromFlag
+                                         , installVerbosity
+                                         )
+import "Cabal" Distribution.Verbosity ( Verbosity )
 
 import System.IO ( openFile
                  , IOMode (WriteMode)


### PR DESCRIPTION
If we don't do this, Cabal tries to use the local modules to build etlas-cabal and then has ambiguity when building etlas.