### PR TITLE
Windows support for "etlas run --trace"

### DIFF
--- a/etlas-cabal/Distribution/Simple/Eta.hs
+++ b/etlas-cabal/Distribution/Simple/Eta.hs
@@ -327,12 +327,12 @@ buildOrReplExe _forRepl verbosity numJobs pkgDescr lbi
 
   maybeMavenOutput <- if null mavenDeps
                       then return Nothing
-                      else fmap Just (runCoursier $ "fetch"
+                      else fmap Just (runCoursier $ "fetch" : "--quiet"
                                                   : (mavenResolvedRepos ++
                                                      mavenDeps))
 
   let mavenPaths = case maybeMavenOutput of
-        Just mavenOutput -> dropWhile ((/= '/') . head) $ lines mavenOutput
+        Just mavenOutput -> lines mavenOutput
         Nothing          -> []
       javaSrcs = (if isShared
                   then []

--- a/etlas/Distribution/Client/Run.hs
+++ b/etlas/Distribution/Client/Run.hs
@@ -157,10 +157,8 @@ run verbosity debug trace lbi exe exeArgs = do
                     runCoursier options = getProgramInvocationOutput verbosity
                                             (programInvocation javaProg $
                                               (["-jar", "-noverify", coursierPath] ++ options))
-                    stripClearLine str = fromMaybe str $ stripPrefix "\033[2K" str
                     getTracePaths = do
-                      output <- stripClearLine `fmap`
-                                runCoursier ["fetch", "--quiet"
+                      output <- runCoursier ["fetch", "--quiet"
                                                     , "org.slf4j:slf4j-ext:1.7.21"
                                                     , "org.slf4j:slf4j-simple:1.7.21"
                                                     , "org.slf4j:slf4j-api:1.7.21"

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,61 +1,17 @@
-resolver: lts-6.27
-packages:
-- etlas-cabal/
-- etlas/
-- hackage-security/hackage-security
 extra-deps:
-# - aeson-1.1.0.0
-# - ansi-terminal-0.6.2.3
-# - ansi-wl-pprint-0.6.7.3
-# - async-2.1.0
-# - attoparsec-0.13.1.0
-# - base-compat-0.9.1
-# - base16-bytestring-0.1.1.6
-# - base64-bytestring-1.0.0.1
-# - clock-0.7.2
 - cryptohash-sha256-0.11.100.1
-# - dlist-0.8.0.2
 - echo-0.1.3
 - ed25519-0.0.5.0
-# - edit-distance-0.2.2.1
-# - exceptions-0.8.2.1
-- hackage-security-0.5.2.2
-# - hashable-1.2.4.0
-# - haskell-lexer-1.0
-# - HTTP-4000.3.3
-# - integer-logarithms-1
-# - mtl-2.2.1
-# - network-2.6.2.1
-# - network-uri-2.6.1.0
-# - optparse-applicative-0.12.1.0
-# - parsec-3.1.11
-# - pretty-show-1.6.10
-# - primitive-0.6.1.0
-# - QuickCheck-2.8.2
-# - random-1.1
-# - regex-base-0.93.2
-# - regex-posix-0.95.2
-# - regex-tdfa-1.2.2
-# - scientific-0.3.4.10
-# - stm-2.4.4.1
-# - tagged-0.8.4
-# - tar-0.5.0.3
-# - tasty-0.11.0.4
-# - tasty-hunit-0.9.2
-# - tasty-quickcheck-0.8.4
-# - text-1.2.2.1
-# - tf-random-0.5
-- time-locale-compat-0.1.1.3
-# - transformers-compat-0.5.1.4
-# - unbounded-delays-0.1.0.9
-# - unordered-containers-0.2.7.2
-# - uuid-types-1.0.3
-# - vector-0.12.0.0
-# - zlib-0.6.1.1
+- mintty-0.1.1
+resolver: lts-6.27
 flags:
   etlas-cabal:
     parsec: true
   etlas:
     parsec: true
-  time-locale-compat:
-    old-locale: false
+  mintty:
+    win32-2-5: false
+packages:
+- etlas-cabal/
+- etlas/
+- hackage-security/hackage-security


### PR DESCRIPTION
* i've included the changes needed in cabal config to get working the build of etlas in windows
* i've tested that `etlas run --trace" works (prints the trace of the execution to system out)
* i have to test that the change in etlas-cabal/Distribution/Simple/Eta.hs works and test if the stripClearLine is really needed