### PR TITLE
Updated hackage URI.

### DIFF
--- a/etlas/Distribution/Client/Config.hs
+++ b/etlas/Distribution/Client/Config.hs
@@ -533,7 +533,7 @@ defaultRemoteRepos = [ RemoteRepo hackageName hackageUri Nothing [] 0 False Fals
   where
     hackageName = "hackage.haskell.org"
     hackageUri  = URI "http:" (Just (URIAuth "" hackageName ""))
-                      "/packages/archive" "" ""
+                      "/" "" ""
     etlasName = "etlas.typelead.com"
     etlasUri  = URI "http:" (Just (URIAuth "" "github.com" ""))
                       "/typelead/etlas-index" "" ""


### PR DESCRIPTION
 Avoid "Page not found. Sorry, it's just not here. " responses.
At least partially resolves https://github.com/typelead/eta/issues/313.