### PR TITLE
Fix etlas run for windows

### DIFF
--- a/etlas-cabal/Distribution/Simple/Eta.hs
+++ b/etlas-cabal/Distribution/Simple/Eta.hs
@@ -388,6 +388,8 @@ buildOrReplExe _forRepl verbosity numJobs pkgDescr lbi
               | hasJavaSources = [exeTmpDir </> extrasJar]
               | otherwise      = []
             relativeClassPaths = map (mkRelative targetDir') classPaths
+            withStartingPathSeparatorCPs = map (addStartingPathSeparator)
+                                           relativeClassPaths 
             targetManifest = targetDir </> "MANIFEST.MF"
             launcherJar = targetDir </> (exeName' ++ ".launcher.jar")
         writeFile targetManifest $ unlines $
@@ -395,7 +397,7 @@ buildOrReplExe _forRepl verbosity numJobs pkgDescr lbi
           ,"Created-By: etlas-" ++ display Etlas.version
           ,"Main-Class: eta.main"
           ,"Class-Path: " ++ exeNameReal]
-          ++ map ((++) "  ") (maybeJavaSourceAttr ++ relativeClassPaths)
+          ++ map ((++) "  ") (maybeJavaSourceAttr ++ withStartingPathSeparatorCPs)
         -- Create the launcher jar
         runProgramInvocation verbosity
           $ programInvocation jarProg ["cfm", launcherJar, targetManifest]
@@ -425,6 +427,10 @@ mkRelative base target = intercalate [pathSeparator]
         numDots = length $ drop numEqualParts baseSplit
         baseSplit   = splitPath base
         targetSplit = splitPath target
+
+addStartingPathSeparator :: FilePath -> FilePath
+addStartingPathSeparator path | isAbsolute path = pathSeparator : path
+                              | otherwise       = path
 
 -- |Install for ghc, .hi, .a and, if --with-ghci given, .o
 installLib    :: Verbosity


### PR DESCRIPTION
In windows 7 and with java 1.8.0_101 the command etla run failed for me with:
`Could not find or load main class eta.mian`
[It seems in windows](http://todayguesswhat.blogspot.com.es/2011/03/jar-manifestmf-class-path-referencing.html) you have to add an extra `\` to absolute paths starting with the drive letter. 
After adding it with this version the launcher works.