### PR TITLE
Fix classpath of launchers installed globally 

### DIFF
--- a/etlas-cabal/Distribution/Simple/Eta.hs
+++ b/etlas-cabal/Distribution/Simple/Eta.hs
@@ -637,17 +637,18 @@ getDependencyClassPaths
 getDependencyClassPaths packageIndex pkgDescr lbi clbi bi runScript
   | Left closurePackageIndex <- closurePackageIndex'
   = do let packageInfos = PackageIndex.allPackages closurePackageIndex
-           mavenDeps = concatMap InstalledPackageInfo.extraLibraries packageInfos
+           packageMavenDeps = concatMap InstalledPackageInfo.extraLibraries packageInfos
            hsLibraryPaths pinfo = mapM (findFile (libraryDirs pinfo))
                                        (map (<.> "jar") $ hsLibraries pinfo)
-
-       libs' <- fmap concat $ mapM hsLibraryPaths packageInfos
-       return $ Just (libPaths ++ libs', extraLibs bi ++ libMavenDeps ++ mavenDeps)
+       
+       packagesPaths <- fmap concat $ mapM hsLibraryPaths packageInfos
+       return $ Just (libPath ++ packagesPaths, mavenDeps ++ libMavenDeps ++ packageMavenDeps)
 
   | otherwise = return Nothing
   where closurePackageIndex' = PackageIndex.dependencyClosure packageIndex packages
           where packages  = libDeps ++ packages''
-        libPaths
+        mavenDeps = extraLibs bi
+        libPath
           | null libs = []
           | runScript = [dirEnvVarRef ++ "/../" ++ libJarName]
           | otherwise = [buildDir lbi </> libJarName]

--- a/etlas-cabal/Distribution/Simple/Eta.hs
+++ b/etlas-cabal/Distribution/Simple/Eta.hs
@@ -528,8 +528,7 @@ installExe verbosity lbi clbi installDirs buildPref
             | otherwise = []
       generateExeLaunchers verbosity lbi exeName' classPaths installLaunchersDir
       copy installLaunchersDir (exeNameExt launchExt) 
-      when (isWindows lbi) $ do
-        --generateExeLaunchJar installDir
+      when (isWindows lbi) $
         copy installLaunchersDir (exeNameExt "launcher.jar")
 
 libAbiHash :: Verbosity -> PackageDescription -> LocalBuildInfo

--- a/etlas-cabal/Distribution/Simple/Eta.hs
+++ b/etlas-cabal/Distribution/Simple/Eta.hs
@@ -339,8 +339,9 @@ buildOrReplExe _forRepl verbosity numJobs pkgDescr lbi
             | isShared  = javaSrcs'
             | otherwise = mavenPaths ++ javaSrcs'
           hasJavaSources = isShared && not (null javaSrcs)
-          maybeJavaSourceAttr | hasJavaSources = [exeTmpDir </> extrasJar]
-                              | otherwise      = []
+          maybeJavaSourceAttr
+            | hasJavaSources = [exeTmpDir </> extrasJar]
+            | otherwise      = []
 
           runEtaProg  = runGHC verbosity etaProg comp (hostPlatform lbi)
           baseOpts = (componentGhcOptions verbosity lbi exeBi clbi exeDir)
@@ -375,8 +376,8 @@ dirEnvVarAndRef isWindows = (var,ref)
         ref | isWindows = "%" ++ var ++ "%"
             | otherwise  = "$" ++ var 
 
-generateExeLaunchers :: Verbosity -> LocalBuildInfo -> String ->
-                        [String] -> [String] -> FilePath -> IO ()
+generateExeLaunchers :: Verbosity -> LocalBuildInfo -> String
+                     -> [String] -> [String] -> FilePath -> IO ()
 generateExeLaunchers verbosity lbi exeName classPaths maybeJavaSourceAttr targetDir = do
   let maybeJavaSourceEnv = map (dirEnvVarRef </>) maybeJavaSourceAttr
       scriptClassPaths

--- a/etlas-cabal/Distribution/Simple/Install.hs
+++ b/etlas-cabal/Distribution/Simple/Install.hs
@@ -219,7 +219,7 @@ copyComponent verbosity pkg_descr lbi (CExe exe) clbi copydest = do
     case compilerFlavor (compiler lbi) of
       GHC   -> GHC.installExe   verbosity lbi installDirs buildPref (progPrefixPref, progSuffixPref) pkg_descr exe
       GHCJS -> GHCJS.installExe verbosity lbi installDirs buildPref (progPrefixPref, progSuffixPref) pkg_descr exe
-      Eta   -> Eta.installExe   verbosity lbi clbi installDirs buildPref (progPrefixPref, progSuffixPref) pkg_descr exe
+      Eta   -> Eta.installExe   verbosity lbi installDirs buildPref (progPrefixPref, progSuffixPref) pkg_descr exe
       LHC   -> LHC.installExe   verbosity lbi installDirs buildPref (progPrefixPref, progSuffixPref) pkg_descr exe
       JHC   -> JHC.installExe   verbosity binPref buildPref (progPrefixPref, progSuffixPref) pkg_descr exe
       UHC   -> return ()

--- a/etlas-cabal/Distribution/Simple/Install.hs
+++ b/etlas-cabal/Distribution/Simple/Install.hs
@@ -219,7 +219,7 @@ copyComponent verbosity pkg_descr lbi (CExe exe) clbi copydest = do
     case compilerFlavor (compiler lbi) of
       GHC   -> GHC.installExe   verbosity lbi installDirs buildPref (progPrefixPref, progSuffixPref) pkg_descr exe
       GHCJS -> GHCJS.installExe verbosity lbi installDirs buildPref (progPrefixPref, progSuffixPref) pkg_descr exe
-      Eta   -> Eta.installExe verbosity lbi installDirs buildPref (progPrefixPref, progSuffixPref) pkg_descr exe
+      Eta   -> Eta.installExe   verbosity lbi clbi installDirs buildPref (progPrefixPref, progSuffixPref) pkg_descr exe
       LHC   -> LHC.installExe   verbosity lbi installDirs buildPref (progPrefixPref, progSuffixPref) pkg_descr exe
       JHC   -> JHC.installExe   verbosity binPref buildPref (progPrefixPref, progSuffixPref) pkg_descr exe
       UHC   -> return ()

--- a/etlas/main/Main.hs
+++ b/etlas/main/Main.hs
@@ -161,7 +161,7 @@ import Distribution.Types.Benchmark
 import Distribution.Types.TargetInfo
 
 import Distribution.Simple.Eta ( findVerifyRef, findCoursierRef, getLibraryComponent
-                               , getDependencyClassPaths, LibraryPathType(..),mkJarName, exeJarPath
+                               , getDependencyClassPaths, InstallDirType(..),mkJarName, exeJarPath
                                , libJarPath )
 import Distribution.Simple.Build
          ( startInterpreter )
@@ -456,7 +456,8 @@ depsAction depsFlags extraArgs globalFlags' = do
   let clbi = targetCLBI target
       comp = targetComponent target
       cbi  = LBI.componentBuildInfo comp
-  mResult <- getDependencyClassPaths (LBI.installedPkgs lbi) pkgDescr lbi clbi cbi AbsoluteLocalLibPath
+  mResult <- getDependencyClassPaths (LBI.installedPkgs lbi)
+               pkgDescr lbi clbi cbi AbsoluteLocalInstallDir
   case mResult of
     Just (depJars, mavenDeps) ->
       if | depsMavenFlag -> mapM_ (notice normal) mavenDeps

--- a/etlas/main/Main.hs
+++ b/etlas/main/Main.hs
@@ -14,7 +14,6 @@
 -----------------------------------------------------------------------------
 
 module Main (main) where
-
 import Distribution.Client.Setup
          ( GlobalFlags(..), globalCommand, withRepoContext
          , ConfigFlags(..)
@@ -162,7 +161,7 @@ import Distribution.Types.Benchmark
 import Distribution.Types.TargetInfo
 
 import Distribution.Simple.Eta ( findVerifyRef, findCoursierRef, getLibraryComponent
-                               , getDependencyClassPaths, mkJarName, exeJarPath
+                               , getDependencyClassPaths, LibraryPathType(..),mkJarName, exeJarPath
                                , libJarPath )
 import Distribution.Simple.Build
          ( startInterpreter )
@@ -457,7 +456,7 @@ depsAction depsFlags extraArgs globalFlags' = do
   let clbi = targetCLBI target
       comp = targetComponent target
       cbi  = LBI.componentBuildInfo comp
-  mResult <- getDependencyClassPaths (LBI.installedPkgs lbi) pkgDescr lbi clbi cbi False
+  mResult <- getDependencyClassPaths (LBI.installedPkgs lbi) pkgDescr lbi clbi cbi AbsoluteLocalLibPath
   case mResult of
     Just (depJars, mavenDeps) ->
       if | depsMavenFlag -> mapM_ (notice normal) mavenDeps


### PR DESCRIPTION
* With this version, in the build phase two versions of launchers (script and jar for windows) are created: one to be executed in place and another to be copied and executed in the etlas global bin path (`~/etlas/bin`). Each one has a different classpath.
* To fix https://github.com/typelead/eta/issues/582