### PR TITLE
Handle executables file extension for windows

### DIFF
--- a/etlas-cabal/Distribution/Simple/BuildPaths.hs
+++ b/etlas-cabal/Distribution/Simple/BuildPaths.hs
@@ -134,7 +134,7 @@ mkSharedLibName (CompilerId compilerFlavor compilerVersion) lib
 -- (typically @\"\"@ on Unix and @\"exe\"@ on Windows or OS\/2)
 exeExtension :: String
 exeExtension = case buildOS of
-                   Windows -> "exe"
+                   Windows -> "cmd"
                    _       -> ""
 
 -- | Extension for object files. For GHC the extension is @\"o\"@.

--- a/etlas-cabal/Distribution/Simple/Utils.hs
+++ b/etlas-cabal/Distribution/Simple/Utils.hs
@@ -1459,7 +1459,7 @@ exeExtensions = case buildOS of
   -- Possible improvement: on Windows, read the list of extensions from the
   -- PATHEXT environment variable. By default PATHEXT is ".com; .exe; .bat;
   -- .cmd".
-  Windows -> ["", "exe"]
+  Windows -> ["", "exe","com","bat","cmd"]
   Ghcjs   -> ["", "exe"]
   _       -> [""]
 


### PR DESCRIPTION
Changes:
* Add the default possible win executable file extensions (including the actual used by eta `cmd`) so `etlas exec` works without extension
  * Although the complete list of extensions (in windows 7) is `.COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC`, i've added only `.COM;.EXE;.BAT;.CMD`
* Set the default executable file extension to cmd if the build os is windows so internals calls to execute programs finds the correct win script launcher (f.e. when running `etlas test`)