### PR TITLE
loopification: #866 in eta

### DIFF
--- a/etlas-cabal/Distribution/Simple/Program/GHC.hs
+++ b/etlas-cabal/Distribution/Simple/Program/GHC.hs
@@ -323,7 +323,7 @@ renderGhcOptions comp _platform@(Platform _arch os) opts
 
   , case flagToMaybe (ghcOptOptimisation opts) of
       Nothing                         -> []
-      Just GhcNoOptimisation          -> ["-O0"]
+      Just GhcNoOptimisation          -> ["-O0", "-floopification"]
       Just GhcNormalOptimisation      -> ["-O"]
       Just GhcMaximumOptimisation     -> ["-O2"]
       Just (GhcSpecialOptimisation s) -> ["-O" ++ s] -- eg -Odph


### PR DESCRIPTION
As part of the pull request for addressing [eta: #866](https://github.com/typelead/eta/issues/866).

Since etlas repl by default removes all optimizations, I had to patch etlas itself too. This way the user can still turn off loopification if desired.