### PR TITLE
Fix 'etlas install --builddir' ambiguity

### DIFF
--- a/etlas/Distribution/Client/CmdInstall.hs
+++ b/etlas/Distribution/Client/CmdInstall.hs
@@ -180,7 +180,7 @@ installCommand = CommandUI
         -- hide "constraint", "dependency", and
         -- "exact-configuration" from the configure options.
         (filter ((`notElem` ["constraint", "dependency"
-                            , "exact-configuration"])
+                            , "exact-configuration", "builddir"])
                  . optionName) $ configureOptions showOrParseArgs)
      ++ liftOptions get2 set2 (configureExOptions showOrParseArgs ConstraintSourceCommandlineFlag)
      ++ liftOptions get3 set3


### PR DESCRIPTION
Fix the following behavior of `etlas install --builddir` :

```shell
➜  eta etlas install --builddir dist
etlas: option `--builddir' is ambiguous; could be one of:
--builddir=DIR The directory where Etlas puts generated build files (default dist)
--builddir=DIR The directory where Etlas puts generated build files (default dist)
```