### PR TITLE
Use dhall builtin cache to speed up etlas.dhall use

### DIFF
--- a/etlas/Distribution/Client/IndexUtils.hs
+++ b/etlas/Distribution/Client/IndexUtils.hs
@@ -80,7 +80,9 @@ import Distribution.Client.Setup
 import Distribution.Simple.Command
 import qualified Distribution.Simple.Eta as Eta
 import qualified Distribution.Client.PackageDescription.Dhall as PackageDesc.Parse
-         ( readGenericPackageDescription, parseGenericPackageDescriptionFromDhall )
+         ( readGenericPackageDescription )
+import qualified Distribution.Client.PackageDescription.Dhall as PackageDescription.Dhall
+         ( parse )
 #ifdef CABAL_PARSEC
 import Distribution.PackageDescription.Parsec
          ( parseGenericPackageDescriptionMaybe, parseGenericPackageDescription, runParseResult  )
@@ -545,7 +547,7 @@ extractPkg verbosity entry blockNo = case Tar.entryContent entry of
                     Nothing -> error $ "Couldn't read etlas or cabal file "
                                      ++ show fileName
               parsed = if takeExtension fileName == ".dhall"
-                then fmap Just $ PackageDesc.Parse.parseGenericPackageDescriptionFromDhall fileName
+                then fmap Just $ PackageDescription.Dhall.parse fileName
                                $ StrictText.decodeUtf8 $ BS.toStrict content
                 else return $
 #ifdef CABAL_PARSEC
@@ -842,8 +844,8 @@ packageListFromCache verbosity mkPkg idxFile hnd Cache{..} mode patchesDir
     parsePackageDescription :: FilePath -> ByteString -> IO GenericPackageDescription
     parsePackageDescription fileName content = do
       if takeExtension fileName == ".dhall"
-        then PackageDesc.Parse.parseGenericPackageDescriptionFromDhall fileName
-                     $ StrictText.decodeUtf8 $ BS.toStrict content
+        then PackageDescription.Dhall.parse fileName
+               $ StrictText.decodeUtf8 $ BS.toStrict content
         else
 #ifdef CABAL_PARSEC
           do

--- a/etlas/Distribution/Client/Init.hs
+++ b/etlas/Distribution/Client/Init.hs
@@ -844,7 +844,7 @@ generateCabalFile fileName c =
                 (Just "Extra files to be distributed with the package, such as examples or a README.")
                 True
 
-       , field  "cabal-version" (Flag $ orLaterVersion (mkVersion [1,10]))
+       , field  "cabal-version" (Flag $ mkVersion [1,12])
                 (Just "Constraint on the version of Cabal needed to build this package.")
                 False
 

--- a/etlas/Distribution/Client/PackageDescription/Dhall.hs
+++ b/etlas/Distribution/Client/PackageDescription/Dhall.hs
@@ -51,8 +51,7 @@ readCachedDhallGenericPackageDescription :: Verbosity -> FilePath
                                          -> IO GenericPackageDescription
 readCachedDhallGenericPackageDescription verbosity dhallFilePath  = do
 
-  let cacheDir = takeDirectory dhallFilePath </> "dist" </> "cache"
-      derivedCabalFilePath = cacheDir </> getDerivedCabalFileName dhallFilePath
+  let derivedCabalFilePath = getDerivedCabalFilePath dhallFilePath
 
   exists <- doesFileExist derivedCabalFilePath
   
@@ -102,6 +101,12 @@ parseGenericPackageDescriptionFromDhall dhallFilePath content = do
          & Lens.set Dhall.rootDirectory ( takeDirectory dhallFilePath )
          & Lens.set Dhall.sourceName dhallFilePath
   fmap fixGPDConstraints $ dhallToCabal settings content
+
+getDerivedCabalFilePath :: FilePath -> FilePath 
+getDerivedCabalFilePath dhallFilePath =
+  cacheDir </> getDerivedCabalFileName dhallFilePath
+  where cacheDir = takeDirectory dhallFilePath </> "dist" </> "cache"
+  
 
 getDerivedCabalFileName :: FilePath -> FilePath
 getDerivedCabalFileName dhallFilePath = hexStr ++ ".cabal"

--- a/etlas/Distribution/Client/PackageDescription/Dhall.hs
+++ b/etlas/Distribution/Client/PackageDescription/Dhall.hs
@@ -153,6 +153,20 @@ parseAndCacheGenericPackageDescriptionFromDhall dhallFilePath src = do
                           dhallFilePath src
   cacheAndExtractGenericPackageDescriptionFromDhall hash normExpr dhallFilePath
 
+parseAndHashGenericPackageDescriptionFromDhall :: FilePath -> StrictText.Text
+                                                -> IO ( Crypto.Hash.Digest Crypto.Hash.SHA256
+                                                      , Dhall.Expr Dhall.Src Dhall.X
+                                                      ) 
+parseAndHashGenericPackageDescriptionFromDhall dhallFilePath src = do
+  let  settings = Dhall.defaultInputSettings
+         & Lens.set Dhall.rootDirectory ( takeDirectory dhallFilePath )
+         & Lens.set Dhall.sourceName dhallFilePath
+  expr  <- Dhall.inputExprWithSettings settings src
+  let normExpr = Dhall.alphaNormalize expr
+      hash = Dhall.hashExpression Dhall.defaultStandardVersion normExpr
+  return ( hash, normExpr )
+
+
 cacheAndExtractGenericPackageDescriptionFromDhall :: Crypto.Hash.Digest Crypto.Hash.SHA256
                                                   -> Dhall.Expr Dhall.Src Dhall.X
                                                   -> FilePath
@@ -174,19 +188,7 @@ extractGenericPackageDescriptionFromDhall expr = do
                                ( error "Empty extracted GenericPackageDescription" )
                                ( extract expr ) )
   where throws = either Control.Exception.throwIO return
-  
-parseAndHashGenericPackageDescriptionFromDhall :: FilePath -> StrictText.Text
-                                                -> IO ( Crypto.Hash.Digest Crypto.Hash.SHA256
-                                                      , Dhall.Expr Dhall.Src Dhall.X
-                                                      ) 
-parseAndHashGenericPackageDescriptionFromDhall dhallFilePath src = do
-  let  settings = Dhall.defaultInputSettings
-         & Lens.set Dhall.rootDirectory ( takeDirectory dhallFilePath )
-         & Lens.set Dhall.sourceName dhallFilePath
-  expr  <- Dhall.inputExprWithSettings settings src
-  let normExpr = Dhall.alphaNormalize expr
-      hash = Dhall.hashExpression Dhall.defaultStandardVersion normExpr
-  return ( hash, normExpr )
+
 
 writeDhallToCache :: Crypto.Hash.Digest Crypto.Hash.SHA256
                   -> Dhall.Expr Dhall.Src Dhall.X

--- a/etlas/Distribution/Client/PackageDescription/Dhall.hs
+++ b/etlas/Distribution/Client/PackageDescription/Dhall.hs
@@ -151,10 +151,7 @@ readAndCache verbosity dhallFilePath = do
 
 parseAndCache :: FilePath -> StrictText.Text -> IO GenericPackageDescription 
 parseAndCache dhallFilePath src = do
-  let Dhall.Type {..} = genericPackageDescription
-
   ( hash, normExpr ) <- parseAndHash dhallFilePath src
-
   cacheAndExtract hash normExpr dhallFilePath
 
 

--- a/etlas/Distribution/Client/PackageDescription/Dhall.hs
+++ b/etlas/Distribution/Client/PackageDescription/Dhall.hs
@@ -32,7 +32,7 @@ import Lens.Micro (Lens')
 import qualified Lens.Micro.Extras as Lens
 
 import System.Directory (doesFileExist)
-import System.FilePath (takeDirectory, takeExtension, (</>))
+import System.FilePath (takeDirectory, takeExtension)
 import System.CPUTime (getCPUTime)
 import Control.Monad    (unless)
 
@@ -83,15 +83,15 @@ parseGenericPackageDescriptionFromDhall dhallFilePath content = do
          & Lens.set Dhall.sourceName dhallFilePath
   fmap fixGPDConstraints $ dhallToCabal settings content
 
+-- writeDerivedCabalFileFromDhallFile :: 
 
 writeDerivedCabalFile :: Verbosity -> FilePath
-                      -> GenericPackageDescription -> IO FilePath
-writeDerivedCabalFile verbosity dir genPkg = do
-  let path = dir </> "etlas.dhall.cabal"
+                      -> GenericPackageDescription -> IO ()
+writeDerivedCabalFile verbosity path genPkg = do
   info verbosity $ "Writing derived cabal file from dhall file: " ++ path
+  let dir = takeDirectory path
   createDirectoryIfMissingVerbose verbosity True dir
   writeGenericPackageDescription path genPkg
-  return path
 
 -- TODO: Pick Lens modules from Cabal if we need them in more places
 condLibrary' :: Lens' GenericPackageDescription (Maybe (CondTree ConfVar [Dependency] Library))

--- a/etlas/Distribution/Client/ProjectConfig.hs
+++ b/etlas/Distribution/Client/ProjectConfig.hs
@@ -119,7 +119,6 @@ import Distribution.ParseUtils
 import Control.Monad
 import Control.Monad.Trans (liftIO)
 import Control.Exception
-import qualified Data.Hashable as Hashable
 import Data.Maybe
 import Data.Either
 import qualified Data.Map as Map
@@ -1012,7 +1011,7 @@ readSourcePackage verbosity distDirLayout
     pkgdesc <- liftIO $
                  Dhall.readDhallGenericPackageDescription verbosity ( dhallPath )
     let cacheDir = distProjectCacheFile distDirLayout
-        cabalFileName = ( show $ Hashable.hash dhallPath ) ++ ".cabal"
+        cabalFileName = Dhall.getDerivedCabalFileName dhallPath
     liftIO $
       Dhall.writeDerivedCabalFile verbosity ( cacheDir cabalFileName ) pkgdesc
     return $ SpecificSourcePackage SourcePackage {

--- a/etlas/Distribution/Client/ProjectConfig.hs
+++ b/etlas/Distribution/Client/ProjectConfig.hs
@@ -1002,7 +1002,7 @@ readSourcePackage verbosity distDirLayout
   where
     dir = takeDirectory cabalFile
 
-readSourcePackage verbosity distDirLayout
+readSourcePackage verbosity _distDirLayout
   (ProjectPackageLocalDhallDirectory dir dhallFile) = do
     root <- askRoot
     let dhallPath = root </> dhallFile
@@ -1010,10 +1010,9 @@ readSourcePackage verbosity distDirLayout
     monitorFiles [ fileMonitorDhall ]
     pkgdesc <- liftIO $
                  Dhall.readDhallGenericPackageDescription verbosity ( dhallPath )
-    let cacheDir = distProjectCacheFile distDirLayout
-        cabalFileName = Dhall.getDerivedCabalFileName dhallPath
+    let cabalFilePath = Dhall.getDerivedCabalFilePath dhallPath
     liftIO $
-      Dhall.writeDerivedCabalFile verbosity ( cacheDir cabalFileName ) pkgdesc
+      Dhall.writeDerivedCabalFile verbosity cabalFilePath  pkgdesc
     return $ SpecificSourcePackage SourcePackage {
       packageInfoId        = packageId pkgdesc,
       packageDescription   = pkgdesc,

--- a/etlas/Distribution/Client/ProjectConfig.hs
+++ b/etlas/Distribution/Client/ProjectConfig.hs
@@ -1005,11 +1005,11 @@ readSourcePackage verbosity distDirLayout
 readSourcePackage verbosity _distDirLayout
   (ProjectPackageLocalDhallDirectory dir dhallFile) = do
     root <- askRoot
-    let dhallPath = root </> dhallFile
-        fileMonitorDhall = monitorFileHashed dhallPath
+    let dhallPath = dir </> dhallFile
+        fileMonitorDhall = monitorFileHashed $ root </> dhallPath
     monitorFiles [ fileMonitorDhall ]
     pkgdesc <-
-      liftIO $ Dhall.readCachedDhallGenericPackageDescription verbosity ( dhallPath )
+      liftIO $ Dhall.readAndCacheGenericPackageDescriptionFromDhall verbosity dhallPath
     return $ SpecificSourcePackage SourcePackage {
       packageInfoId        = packageId pkgdesc,
       packageDescription   = pkgdesc,

--- a/etlas/Distribution/Client/ProjectConfig.hs
+++ b/etlas/Distribution/Client/ProjectConfig.hs
@@ -1005,11 +1005,10 @@ readSourcePackage verbosity distDirLayout
 readSourcePackage verbosity _distDirLayout
   (ProjectPackageLocalDhallDirectory dir dhallFile) = do
     root <- askRoot
-    let dhallPath = dir </> dhallFile
+    let dhallPath = dhallFile
         fileMonitorDhall = monitorFileHashed $ root </> dhallPath
     monitorFiles [ fileMonitorDhall ]
-    pkgdesc <-
-      liftIO $ Dhall.readAndCacheGenericPackageDescriptionFromDhall verbosity dhallPath
+    pkgdesc <- liftIO $ Dhall.readAndCache verbosity dhallPath
     return $ SpecificSourcePackage SourcePackage {
       packageInfoId        = packageId pkgdesc,
       packageDescription   = pkgdesc,

--- a/etlas/Distribution/Client/ProjectConfig.hs
+++ b/etlas/Distribution/Client/ProjectConfig.hs
@@ -1008,10 +1008,10 @@ readSourcePackage verbosity _distDirLayout
     let dhallPath = root </> dhallFile
         fileMonitorDhall = monitorFileHashed dhallPath
     monitorFiles [ fileMonitorDhall ]
-    pkgdesc <- liftIO $
-                 Dhall.readDhallGenericPackageDescription verbosity ( dhallPath )
-    let cabalFilePath = Dhall.getDerivedCabalFilePath dhallPath
-    liftIO $
+    pkgdesc <-
+      liftIO $ Dhall.readDhallGenericPackageDescription verbosity ( dhallPath )
+    liftIO $ do
+      cabalFilePath <- Dhall.getDerivedCabalFilePath dhallPath
       Dhall.writeDerivedCabalFile verbosity cabalFilePath  pkgdesc
     return $ SpecificSourcePackage SourcePackage {
       packageInfoId        = packageId pkgdesc,

--- a/etlas/Distribution/Client/ProjectConfig.hs
+++ b/etlas/Distribution/Client/ProjectConfig.hs
@@ -1009,10 +1009,7 @@ readSourcePackage verbosity _distDirLayout
         fileMonitorDhall = monitorFileHashed dhallPath
     monitorFiles [ fileMonitorDhall ]
     pkgdesc <-
-      liftIO $ Dhall.readDhallGenericPackageDescription verbosity ( dhallPath )
-    liftIO $ do
-      cabalFilePath <- Dhall.getDerivedCabalFilePath dhallPath
-      Dhall.writeDerivedCabalFile verbosity cabalFilePath  pkgdesc
+      liftIO $ Dhall.readCachedDhallGenericPackageDescription verbosity ( dhallPath )
     return $ SpecificSourcePackage SourcePackage {
       packageInfoId        = packageId pkgdesc,
       packageDescription   = pkgdesc,

--- a/etlas/Distribution/Client/SetupWrapper.hs
+++ b/etlas/Distribution/Client/SetupWrapper.hs
@@ -401,8 +401,9 @@ setupWrapper verbosity options mgenPkg mpkg cmd flags extraArgs = do
     if needDerivedCabalFile then do
       let distDir = useDistPref options
           dir = if isAbsolute distDir then distDir else currentDir </> distDir
+          cabalFilePath = dir </> "etlas.dhall.cabal"
           genPkg = setupGenericPackage setup
-      cabalFilePath <- writeDerivedCabalFile verbosity dir genPkg
+      writeDerivedCabalFile verbosity cabalFilePath genPkg
       absCabalFilePath <- makeAbsoluteToCwd cabalFilePath
       return ["--cabal-file", absCabalFilePath]
     else return []

--- a/etlas/Distribution/Client/Targets.hs
+++ b/etlas/Distribution/Client/Targets.hs
@@ -95,8 +95,9 @@ import Distribution.Simple.Utils
 import qualified Data.ByteString.Lazy.Char8 as BS.Char8
 #endif
 import Distribution.Client.PackageDescription.Dhall
-         ( readGenericPackageDescription, parseGenericPackageDescriptionFromDhall )
-
+         ( readGenericPackageDescription )
+import qualified Distribution.Client.PackageDescription.Dhall as PackageDescription.Dhall
+  ( parse )
 -- import Data.List ( find, nub )
 import Data.Either
          ( partitionEithers )
@@ -539,7 +540,7 @@ readPackageTarget verbosity = traverse modifyLocation
                              -> IO (Maybe GenericPackageDescription)
     parsePackageDescription' filePath content =
       if takeExtension filePath == ".dhall" 
-        then fmap Just $ parseGenericPackageDescriptionFromDhall filePath
+        then fmap Just $ PackageDescription.Dhall.parse filePath
                        $ StrictText.decodeUtf8 $ BS.toStrict content
         else return $
 #ifdef CABAL_PARSEC

--- a/etlas/etlas.cabal
+++ b/etlas/etlas.cabal
@@ -200,6 +200,7 @@ library
         base16-bytestring >= 0.1.1 && < 0.2,
         binary     >= 0.5      && < 0.9,
         bytestring >= 0.9      && < 1,
+        cryptonite  >= 0.23     && < 1.0,
         etlas-cabal >= 1.0,
         dhall      >= 1.19.0   && < 1.20,         
         dhall-to-etlas >= 1.3,
@@ -225,8 +226,11 @@ library
         network    >= 2.6 && < 2.7,
         text >= 1.2,          
         parsec >= 3.1.13.0 && < 3.2,
-        microlens >=0.1.0.0 && <0.5     
-                  
+        microlens >=0.1.0.0 && <0.5
+    if !impl(ghc >= 8.0)
+        build-depends: semigroups == 0.18.*,
+                       transformers == 0.4.2.*
+                                      
     if os(windows)
       build-depends: Win32 >= 2 && < 3
     else


### PR DESCRIPTION
* etlas save an additional file named with canonical path to `dhall.etlas` hashed and put the dhall cache key in
  * it save it in the <etlas.dhall dir>/dist/cache
* in subsequent config uses it reads that file, retrieves de dhall cache key and uses it 
