### PR TITLE
Fix eta-pkg error when specific package db dir not exists

### DIFF
--- a/etlas-cabal/Distribution/Simple/Eta.hs
+++ b/etlas-cabal/Distribution/Simple/Eta.hs
@@ -156,9 +156,12 @@ getInstalledPackages' :: Verbosity -> [PackageDB] -> ProgramDb
                       -> IO [(PackageDB, [InstalledPackageInfo])]
 getInstalledPackages' verbosity packagedbs progdb =
   sequence
-    [ do pkgs <- HcPkg.dump (hcPkgInfo progdb) verbosity packagedb
+    [ do createDir packagedb
+         pkgs <- HcPkg.dump (hcPkgInfo progdb) verbosity packagedb
          return (packagedb, pkgs)
     | packagedb <- packagedbs ]
+  where createDir (SpecificPackageDB path) = createDirectoryIfMissing True path
+        createDir _ = return ()
 
 trimEnd :: String -> String
 trimEnd = reverse . dropWhile isSpace . reverse

--- a/etlas/Distribution/Client/CmdInstall.hs
+++ b/etlas/Distribution/Client/CmdInstall.hs
@@ -451,8 +451,8 @@ installAction (configFlags, configExFlags, installFlags, haddockFlags, newInstal
     else return []
 
   cabalDir <- defaultCabalDir
+  mstoreDir <- sequenceA $ makeAbsolute <$> flagToMaybe (globalStoreDir globalFlags)
   let
-    mstoreDir   = flagToMaybe (globalStoreDir globalFlags)
     mlogsDir    = flagToMaybe (globalLogsDir globalFlags)
     cabalLayout = mkCabalDirLayout cabalDir mstoreDir mlogsDir
     packageDbs  = storePackageDBStack (cabalStoreDirLayout cabalLayout) compilerId


### PR DESCRIPTION
* Maybe it should be fixed in `eta-pkg` itself but it will work for now
* it would close #65 and close #58
