### PR TITLE
Reorganize commands names and help

### DIFF
--- a/etlas-cabal/Distribution/Simple/Setup.hs
+++ b/etlas-cabal/Distribution/Simple/Setup.hs
@@ -2123,7 +2123,7 @@ defaultBenchmarkFlags  = BenchmarkFlags {
 
 benchmarkCommand :: CommandUI BenchmarkFlags
 benchmarkCommand = CommandUI
-  { commandName         = "bench"
+  { commandName         = "old-bench"
   , commandSynopsis     =
       "Run all/specific benchmarks."
   , commandDescription  = Just $ \pname -> wrapText $
@@ -2138,7 +2138,7 @@ benchmarkCommand = CommandUI
       ++ " define actions to be executed before and after running"
       ++ " benchmarks.\n"
   , commandNotes        = Nothing
-  , commandUsage        = usageAlternatives "bench"
+  , commandUsage        = usageAlternatives "old-bench"
       [ "[FLAGS]"
       , "BENCHCOMPONENTS [FLAGS]"
       ]

--- a/etlas/Distribution/Client/CmdBench.hs
+++ b/etlas/Distribution/Client/CmdBench.hs
@@ -35,9 +35,9 @@ import Control.Monad (when)
 
 benchCommand :: CommandUI (ConfigFlags, ConfigExFlags, InstallFlags, HaddockFlags)
 benchCommand = Client.installCommand {
-  commandName         = "new-bench",
+  commandName         = "bench",
   commandSynopsis     = "Run benchmarks",
-  commandUsage        = usageAlternatives "new-bench" [ "[TARGETS] [FLAGS]" ],
+  commandUsage        = usageAlternatives "bench" [ "[TARGETS] [FLAGS]" ],
   commandDescription  = Just $ \_ -> wrapText $
         "Runs the specified benchmarks, first ensuring they are up to "
      ++ "date.\n\n"
@@ -53,13 +53,13 @@ benchCommand = Client.installCommand {
      ++ "'cabal.project.local' and other files.",
   commandNotes        = Just $ \pname ->
         "Examples:\n"
-     ++ "  " ++ pname ++ " new-bench\n"
+     ++ "  " ++ pname ++ " bench\n"
      ++ "    Run all the benchmarks in the package in the current directory\n"
-     ++ "  " ++ pname ++ " new-bench pkgname\n"
+     ++ "  " ++ pname ++ " bench pkgname\n"
      ++ "    Run all the benchmarks in the package named pkgname\n"
-     ++ "  " ++ pname ++ " new-bench cname\n"
+     ++ "  " ++ pname ++ " bench cname\n"
      ++ "    Run the benchmark named cname\n"
-     ++ "  " ++ pname ++ " new-bench cname -O2\n"
+     ++ "  " ++ pname ++ " bench cname -O2\n"
      ++ "    Run the benchmark built with '-O2' (including local libs used)\n\n"
 
      ++ cmdCommonHelpTextNewBuildBeta

--- a/etlas/Distribution/Client/CmdDeps.hs
+++ b/etlas/Distribution/Client/CmdDeps.hs
@@ -64,7 +64,7 @@ import Control.Monad
 depsCommand :: CommandUI (ConfigFlags, ConfigExFlags, InstallFlags, HaddockFlags)
 depsCommand = Client.installCommand {
   commandName         = "deps",
-  commandSynopsis     = "Return the list of all dependency jars and Maven dependencies for the specified targets.",
+  commandSynopsis     = "List all dependencies (jars and maven ones) of targets.",
   commandUsage        = usageAlternatives "deps"
                           [ "[TARGET] [FLAGS] [-- EXECUTABLE_FLAGS]" ],
   commandDescription  = Just $ \pname -> wrapText $

--- a/etlas/Distribution/Client/Setup.hs
+++ b/etlas/Distribution/Client/Setup.hs
@@ -158,6 +158,7 @@ globalCommand commands = CommandUI {
           , "fetch"
           , "list"
           , "info"
+          , "select"
           , "user-config"
           , "get"
           , "init"
@@ -190,7 +191,12 @@ globalCommand commands = CommandUI {
           , "old-docs"
           , "old-test"
           , "old-install"
-          , "new-bench"
+          , "old-sdist"
+          , "old-deps"
+          , "old-clean"
+          , "old-reconfigure"
+          , "old-bench"
+          , "deps"
           ]
         maxlen    = maximum $ [length name | (name, _) <- cmdDescs]
         align str = str ++ replicate (maxlen - length str) ' '
@@ -214,29 +220,31 @@ globalCommand commands = CommandUI {
         , addCmd "info"
         , addCmd "list"
         , addCmd "fetch"
+        , addCmd "select"
         , addCmd "user-config"
         , par
         , startGroup "package"
         , addCmd "get"
         , addCmd "init"
         , par
-        , addCmd "configure"
         , addCmd "build"
-        , addCmd "docs"
-        , addCmd "deps"
-        , addCmd "clean"
-        , par
-        , addCmd "run"
+        , addCmd "configure"
         , addCmd "repl"
+        , addCmd "run"
         , addCmd "test"
         , addCmd "bench"
+        , addCmd "freeze"
+        , addCmd "docs"
+        , addCmd "exec"
+        , addCmd "install"
+        , addCmd "clean"
+        , addCmd "sdist"
         , par
         , addCmd "check"
-        , addCmd "sdist"
         , addCmd "upload"
         , addCmd "report"
         , par
-        , addCmd "freeze"
+        , addCmd "deps"
         , addCmd "gen-bounds"
         , addCmd "outdated"
         , addCmd "hscolour"
@@ -247,14 +255,18 @@ globalCommand commands = CommandUI {
         , startGroup "old-style command (deprecated)"
         , addCmd "old-build"
         , addCmd "old-configure"
-        , addCmd "old-deps"
-        , addCmd "old-docs"
         , addCmd "old-repl"
         , addCmd "old-run"
-        , addCmd "old-install"
         , addCmd "old-test"
-        -- , addCmd "new-bench"
+        , addCmd "old-bench"
         , addCmd "old-freeze"
+        , addCmd "old-docs"
+        , addCmd "old-install"
+        , addCmd "old-clean"
+        , addCmd "old-sdist"
+        , addCmd "old-deps"
+        , addCmd "old-reconfigure"
+
         ] ++ if null otherCmds then [] else par
                                            :startGroup "other"
                                            :[addCmd n | n <- otherCmds])
@@ -590,22 +602,22 @@ instance Semigroup ConfigExFlags where
 reconfigureCommand :: CommandUI (ConfigFlags, ConfigExFlags)
 reconfigureCommand
   = configureExCommand
-    { commandName         = "reconfigure"
+    { commandName         = "old-reconfigure"
     , commandSynopsis     = "Reconfigure the package if necessary."
     , commandDescription  = Just $ \pname -> wrapText $
-         "Run `configure` with the most recently used flags, or append FLAGS "
+         "Run `old-configure` with the most recently used flags, or append FLAGS "
          ++ "to the most recently used configuration. "
-         ++ "Accepts the same flags as `" ++ pname ++ " configure'. "
+         ++ "Accepts the same flags as `" ++ pname ++ " old-configure'. "
          ++ "If the package has never been configured, the default flags are "
          ++ "used."
     , commandNotes        = Just $ \pname ->
         "Examples:\n"
-        ++ "  " ++ pname ++ " reconfigure\n"
+        ++ "  " ++ pname ++ " old-reconfigure\n"
         ++ "    Configure with the most recently used flags.\n"
-        ++ "  " ++ pname ++ " reconfigure -w PATH\n"
+        ++ "  " ++ pname ++ " old-reconfigure -w PATH\n"
         ++ "    Reconfigure with the most recently used flags,\n"
         ++ "    but use the compiler at PATH.\n\n"
-    , commandUsage        = usageAlternatives "reconfigure" [ "[FLAGS]" ]
+    , commandUsage        = usageAlternatives "old-reconfigure" [ "[FLAGS]" ]
     , commandDefaultFlags = mempty
     }
 

--- a/etlas/main/Main.hs
+++ b/etlas/main/Main.hs
@@ -286,7 +286,7 @@ mainWorker args = topHandler $
       , hiddenCmd  unpackCommand unpackAction
       , regularCmd checkCommand checkAction
       , regularCmd sdistCommand sdistAction
-      , regularCmd bdistCommand bdistAction
+      , hiddenCmd bdistCommand bdistAction
       , regularCmd uploadCommand uploadAction
       , regularCmd reportCommand reportAction
       , regularCmd runCommand runAction


### PR DESCRIPTION
* no `new-` commands
* old ones have the `old-` prefix
* reorder in global help

I think help for commands are correct so we can close #70