### PR TITLE
Add dhall as default config file format with `etlas init`

### DIFF
--- a/etlas/Distribution/Client/Init.hs
+++ b/etlas/Distribution/Client/Init.hs
@@ -61,7 +61,7 @@ import qualified Distribution.Types.Dependency as P
 import Language.Haskell.Extension ( Language(..) )
 
 import Distribution.Client.Init.Types
-  ( InitFlags(..), PackageType(..), Category(..) )
+  ( InitFlags(..), PackageType(..), Category(..), ConfigFileFormat(..) )
 import Distribution.Client.Init.Licenses
   ( bsd2, bsd3, gplv2, gplv3, lgpl21, lgpl3, agplv3, apache20, mit, mpl20, isc )
 import Distribution.Client.Init.Heuristics
@@ -487,8 +487,15 @@ incVersion n = alterVersion (incVersion' n)
     incVersion' m (v:vs) = v : incVersion' (m-1) vs
 
 getConfigFileFormat :: InitFlags -> IO InitFlags
-getConfigFileFormat = undefined
-
+getConfigFileFormat flags = do
+  format <-     return (flagToMaybe $ configFileFormat flags)
+            ?>> maybePrompt flags
+                   (either CfgFileDhall `fmap`
+                      promptList "What config file format do you want to use?"
+                      [CfgFileCabal, CfgFileEtlas, CfgFileDhall]
+                      (Just CfgFileDhall) display True)
+            ?>> return (Just CfgFileDhall)
+  return $ flags { configFileFormat = maybeToFlag format }
 ---------------------------------------------------------------------------
 --  Prompting/user interaction  -------------------------------------------
 ---------------------------------------------------------------------------

--- a/etlas/Distribution/Client/Init.hs
+++ b/etlas/Distribution/Client/Init.hs
@@ -146,6 +146,7 @@ extendFlags pkgIx sourcePkgDb =
   >=> getLanguage
   >=> getGenComments
   >=> getModulesBuildToolsAndDeps pkgIx
+  >=> getConfigFileFormat
 
 -- | Combine two actions which may return a value, preferring the first. That
 --   is, run the second action only if the first doesn't return a value.
@@ -484,6 +485,9 @@ incVersion n = alterVersion (incVersion' n)
     incVersion' 0 (v:_)  = [v+1]
     incVersion' m []     = replicate m 0 ++ [1]
     incVersion' m (v:vs) = v : incVersion' (m-1) vs
+
+getConfigFileFormat :: InitFlags -> IO InitFlags
+getConfigFileFormat = undefined
 
 ---------------------------------------------------------------------------
 --  Prompting/user interaction  -------------------------------------------

--- a/etlas/Distribution/Client/Init.hs
+++ b/etlas/Distribution/Client/Init.hs
@@ -51,7 +51,7 @@ import Distribution.Version
   ( Version, mkVersion, alterVersion
   , orLaterVersion, earlierVersion, intersectVersionRanges, VersionRange )
 import Distribution.Verbosity
-  ( Verbosity )
+  ( Verbosity, verbose, silent )
 import Distribution.ModuleName
   ( ModuleName )  -- And for the Text instance
 import Distribution.InstalledPackageInfo
@@ -61,7 +61,8 @@ import qualified Distribution.Types.Dependency as P
 import Language.Haskell.Extension ( Language(..) )
 
 import Distribution.Client.Init.Types
-  ( InitFlags(..), PackageType(..), Category(..), ConfigFileFormat(..) )
+  ( InitFlags(..), PackageType(..), Category(..), ConfigFile(..),
+    getConfigFileName)
 import Distribution.Client.Init.Licenses
   ( bsd2, bsd3, gplv2, gplv3, lgpl21, lgpl3, agplv3, apache20, mit, mpl20, isc )
 import Distribution.Client.Init.Heuristics
@@ -96,7 +97,9 @@ import Distribution.Client.Types
   ( SourcePackageDb(..) )
 import Distribution.Client.Setup
   ( RepoContext(..) )
-
+import Distribution.Client.PackageDescription.Dhall
+  ( writeAndFreezeCabalToDhall )
+  
 initCabal :: Verbosity
           -> PackageDBStack
           -> RepoContext
@@ -121,7 +124,7 @@ initCabal verbosity packageDBs repoCtxt binariesPath comp progdb initFlags = do
   writeChangeLog initFlags'
   createSourceDirectories initFlags'
   createMainHs initFlags'
-  success <- writeEtlasFile initFlags'
+  success <- writeConfigFile initFlags'
 
   when success $ generateWarnings initFlags'
 
@@ -146,7 +149,7 @@ extendFlags pkgIx sourcePkgDb =
   >=> getLanguage
   >=> getGenComments
   >=> getModulesBuildToolsAndDeps pkgIx
-  >=> getConfigFileFormat
+  >=> getConfigFile
 
 -- | Combine two actions which may return a value, preferring the first. That
 --   is, run the second action only if the first doesn't return a value.
@@ -486,16 +489,16 @@ incVersion n = alterVersion (incVersion' n)
     incVersion' m []     = replicate m 0 ++ [1]
     incVersion' m (v:vs) = v : incVersion' (m-1) vs
 
-getConfigFileFormat :: InitFlags -> IO InitFlags
-getConfigFileFormat flags = do
-  format <-     return (flagToMaybe $ configFileFormat flags)
+getConfigFile :: InitFlags -> IO InitFlags
+getConfigFile flags = do
+  cfgFile <-    return (flagToMaybe $ configFile flags)
             ?>> maybePrompt flags
-                   (either CfgFileDhall `fmap`
-                      promptList "What config file format do you want to use?"
-                      [CfgFileCabal, CfgFileEtlas, CfgFileDhall]
-                      (Just CfgFileDhall) display True)
-            ?>> return (Just CfgFileDhall)
-  return $ flags { configFileFormat = maybeToFlag format }
+                   (either (const Dhall) id  `fmap`
+                      promptList "What config file type do you want to use?"
+                      [Cabal, Etlas, Dhall]
+                      (Just Dhall) display True)
+            ?>> return (Just Dhall)
+  return $ flags { configFile = maybeToFlag cfgFile }
 ---------------------------------------------------------------------------
 --  Prompting/user interaction  -------------------------------------------
 ---------------------------------------------------------------------------
@@ -694,21 +697,23 @@ writeChangeLog flags = when (any (== defaultChangeLog) $ maybe [] id (extraSrc f
   pname = maybe "" display $ flagToMaybe $ packageName flags
   pver = maybe "" display $ flagToMaybe $ version flags
 
-
---writeCabalFile :: InitFlags -> IO Bool
---writeCabalFile =  writeConfigFile ".cabal"
-
-writeEtlasFile :: InitFlags -> IO Bool
-writeEtlasFile =  writeConfigFile ".etlas"
-
-writeConfigFile :: String -> InitFlags -> IO Bool
-writeConfigFile _ flags@(InitFlags{packageName = NoFlag}) = do
+writeConfigFile :: InitFlags -> IO Bool
+writeConfigFile flags@(InitFlags{packageName = NoFlag}) = do
   message flags "Error: no package name provided."
   return False
-writeConfigFile ext flags@(InitFlags{packageName = Flag p}) = do
-  let cabalFileName = display p ++ ext
-  message flags $ "Generating " ++ cabalFileName ++ "..."
-  writeFileSafe flags cabalFileName (generateCabalFile cabalFileName flags)
+writeConfigFile flags@(InitFlags{configFile = NoFlag}) = do
+  message flags "Error: no config file type provided."
+  return False
+writeConfigFile flags@(InitFlags{packageName = Flag p, configFile = Flag cfgFile}) = do
+  let configFileName = getConfigFileName cfgFile $ display p
+  message flags $ "Generating " ++ configFileName ++ "..."
+  let cabalStr = generateCabalFile configFileName flags
+  message flags $ "Writing " ++ configFileName ++ "..."
+  moveExistingFile flags configFileName
+  let verb = if minimal flags == Flag True then silent else verbose 
+  case cfgFile of
+    Dhall -> writeAndFreezeCabalToDhall verb configFileName cabalStr
+    _ -> writeFile configFileName cabalStr
   return True
 
 -- | Write a file \"safely\", backing up any existing version (unless

--- a/etlas/Distribution/Client/Init/Types.hs
+++ b/etlas/Distribution/Client/Init/Types.hs
@@ -69,8 +69,9 @@ data InitFlags =
               , sourceDirs   :: Maybe [String]
               , buildTools   :: Maybe [String]
 
-              , initVerbosity :: Flag Verbosity
-              , overwrite     :: Flag Bool
+              , initVerbosity    :: Flag Verbosity
+              , overwrite        :: Flag Bool
+              , configFileFormat :: Flag ConfigFileFormat
               }
   deriving (Show, Generic)
 
@@ -84,6 +85,20 @@ data PackageType = Library | Executable
 instance Text PackageType where
   disp = Disp.text . show
   parse = Parse.choice $ map (fmap read . Parse.string . show) [Library, Executable] -- TODO: eradicateNoParse
+
+data ConfigFileFormat = CfgFileCabal | CfgFileEtlas | CfgFileDhall
+  deriving (Show, Read, Eq)
+
+instance Text ConfigFileFormat where
+  disp = Disp.text . show
+  parse = Parse.choice
+          $ map (fmap read . Parse.string . show)
+              [CfgFileCabal, CfgFileEtlas, CfgFileDhall]
+
+getConfigFileName :: ConfigFileFormat -> String -> String
+getConfigFileName CfgFileCabal pkgName = pkgName ++ ".cabal" 
+getConfigFileName CfgFileEtlas pkgName = pkgName ++ ".etlas" 
+getConfigFileName CfgFileDhall _ = "etlas.dhall"
 
 instance Monoid InitFlags where
   mempty = gmempty

--- a/etlas/Distribution/Client/Init/Types.hs
+++ b/etlas/Distribution/Client/Init/Types.hs
@@ -69,9 +69,9 @@ data InitFlags =
               , sourceDirs   :: Maybe [String]
               , buildTools   :: Maybe [String]
 
-              , initVerbosity    :: Flag Verbosity
-              , overwrite        :: Flag Bool
-              , configFileFormat :: Flag ConfigFileFormat
+              , initVerbosity :: Flag Verbosity
+              , overwrite     :: Flag Bool
+              , configFile    :: Flag ConfigFile
               }
   deriving (Show, Generic)
 
@@ -86,19 +86,19 @@ instance Text PackageType where
   disp = Disp.text . show
   parse = Parse.choice $ map (fmap read . Parse.string . show) [Library, Executable] -- TODO: eradicateNoParse
 
-data ConfigFileFormat = CfgFileCabal | CfgFileEtlas | CfgFileDhall
+data ConfigFile = Cabal | Etlas | Dhall
   deriving (Show, Read, Eq)
 
-instance Text ConfigFileFormat where
+instance Text ConfigFile where
   disp = Disp.text . show
   parse = Parse.choice
           $ map (fmap read . Parse.string . show)
-              [CfgFileCabal, CfgFileEtlas, CfgFileDhall]
+              [Cabal, Etlas, Dhall]
 
-getConfigFileName :: ConfigFileFormat -> String -> String
-getConfigFileName CfgFileCabal pkgName = pkgName ++ ".cabal" 
-getConfigFileName CfgFileEtlas pkgName = pkgName ++ ".etlas" 
-getConfigFileName CfgFileDhall _ = "etlas.dhall"
+getConfigFileName :: ConfigFile -> String -> String
+getConfigFileName Cabal pkgName = pkgName ++ ".cabal" 
+getConfigFileName Etlas pkgName = pkgName ++ ".etlas" 
+getConfigFileName Dhall _ = "etlas.dhall"
 
 instance Monoid InitFlags where
   mempty = gmempty

--- a/etlas/Distribution/Client/PackageDescription/Dhall.hs
+++ b/etlas/Distribution/Client/PackageDescription/Dhall.hs
@@ -267,10 +267,10 @@ writeDerivedCabalFile verbosity path genPkg = do
   createDirectoryIfMissingVerbose verbosity True dir
   writeGenericPackageDescription path genPkg
 
-writeAndFreezeCabalToDhall :: Verbosity -> String -> FilePath -> IO ()
-writeAndFreezeCabalToDhall verbosity cabal path = do
+writeAndFreezeCabalToDhall :: Verbosity -> FilePath -> String -> IO ()
+writeAndFreezeCabalToDhall verbosity path cabal = do
   info verbosity $ "Writing dhall file: " ++ path
-  StrictText.writeFile path (  cabalToDhall cabal )
+  StrictText.writeFile path ( cabalToDhall cabal )
   info verbosity $ "Formatting dhall file: " ++ path
   Dhall.format Dhall.Unicode ( Just path )
   info verbosity $ "Freezing dhall file: " ++ path

--- a/etlas/Distribution/Client/PackageDescription/Dhall.hs
+++ b/etlas/Distribution/Client/PackageDescription/Dhall.hs
@@ -271,9 +271,9 @@ writeAndFreezeCabalToDhall :: Verbosity -> FilePath -> String -> IO ()
 writeAndFreezeCabalToDhall verbosity path cabal = do
   info verbosity $ "Writing dhall file: " ++ path
   StrictText.writeFile path ( cabalToDhall cabal )
-  info verbosity $ "Formatting dhall file: " ++ path
+  info verbosity $ "Formatting dhall file..."
   Dhall.format Dhall.Unicode ( Just path )
-  info verbosity $ "Freezing dhall file: " ++ path
+  info verbosity $ "Freezing dhall file..."
   Dhall.freeze ( Just path ) Dhall.defaultStandardVersion 
   
 cabalToDhall :: String -> Dhall.Text

--- a/etlas/Distribution/Client/Setup.hs
+++ b/etlas/Distribution/Client/Setup.hs
@@ -2107,6 +2107,14 @@ initCommand = CommandUI {
         (reqArg' "TOOL" (Just . (:[]))
                         (fromMaybe []))
 
+      , option [] ["config-file-type"]
+        "Specify the default config file type (Cabal, Etlas or Dhall)."
+        IT.configFile
+        (\v flags -> flags { IT.configFile = v })
+        (reqArg "FILE" (readP_to_E ("Cannot parse config file type: "++)
+                                       (toFlag `fmap` parse))
+                          (flagToList . fmap display))
+      
       , optionVerbosity IT.initVerbosity (\v flags -> flags { IT.initVerbosity = v })
       ]
   }


### PR DESCRIPTION
* Now you can choose between:
  * Cabal format: with `.cabal` or `.etlas` extension
  * Dhall format (the default one)