### PR TITLE
Add parsers following ivy notation for VersionInterval

### DIFF
--- a/etlas-cabal/Distribution/Parsec/Class.hs
+++ b/etlas-cabal/Distribution/Parsec/Class.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 module Distribution.Parsec.Class (
     Parsec(..),
     -- * Warnings
@@ -65,7 +66,9 @@ import           Distribution.Version
                  (Version, VersionRange (..), anyVersion, earlierVersion,
                  intersectVersionRanges, laterVersion, majorBoundVersion,
                  mkVersion, noVersion, orEarlierVersion, orLaterVersion,
-                 thisVersion, unionVersionRanges, withinVersion)
+                 thisVersion, unionVersionRanges, withinVersion,
+                 LowerBound (..), UpperBound(..), mkVersionIntervals,
+                 fromVersionIntervals)
 import           Language.Haskell.Extension
                  (Extension, Language, classifyExtension, classifyLanguage)
 
@@ -230,6 +233,11 @@ instance Parsec VersionRange where
                      (">=", orLaterVersion),
                      ("^>=", majorBoundVersion),
                      ("==", thisVersion) ]
+
+instance Parsec (LowerBound, UpperBound) where
+    parsec = expr
+      where
+        expr = undefined
 
 instance Parsec LibVersionInfo where
     parsec = do

--- a/etlas-cabal/Distribution/Version.hs
+++ b/etlas-cabal/Distribution/Version.hs
@@ -1023,13 +1023,11 @@ instance Text VersionRange where
                               : map parseRangeOp rangeOps
         parseAnyVersion    = Parse.string "-any" >> return AnyVersion
         parseNoVersion     = Parse.string "-none" >> return noVersion
+
         parseVersionInterval = do
-          _ <- Parse.string "-i"
           Parse.skipSpaces
-          vis <- ( parse :: ReadP r VersionInterval )
-          return $ fromVersionIntervals
-                 $ fromMaybe (error "Bad version interval")
-                 $ mkVersionIntervals [vis]
+          vis <- ( parse :: ReadP r VersionIntervals )
+          return $ fromVersionIntervals vis
 
         parseWildcardRange = do
           _ <- Parse.string "=="
@@ -1059,6 +1057,16 @@ instance Text VersionRange where
                      (">=", orLaterVersion),
                      ("^>=", MajorBoundVersion),
                      ("==", ThisVersion) ]
+
+
+instance Text VersionIntervals where
+  disp = Disp.hsep . map disp . versionIntervals
+
+  parse = do
+    vis <- Parse.many1 $ do vi <- (parse :: ReadP r VersionInterval)
+                            Parse.skipSpaces
+                            return vi
+    maybe pfail return $ mkVersionIntervals vis
 
 
 instance Text (LowerBound, UpperBound) where


### PR DESCRIPTION
* As a previous step to add them to `etlas.dhall`: https://github.com/typelead/eta/issues/946#issuecomment-464989055
* As bonus now you can use ivy notation in the field `build-depends` of `.cabal` config:

```
build-depends: base [4.8,4.9) [4.11,4.12)
```
would be equivalent to

```
build-depends: base >=4.8 && < 4.9 || >=4.11 && <4.12
```