### PR TITLE
Replace spaces with %20 in launcher jar classpath

### DIFF
--- a/etlas-cabal/Distribution/Simple/Eta.hs
+++ b/etlas-cabal/Distribution/Simple/Eta.hs
@@ -484,7 +484,8 @@ generateExeLauncherJar verbosity lbi exeName classPaths targetDir = do
                                 | otherwise      = path
         (_, dirEnvVarRef) = dirEnvVarAndRef $ isWindows lbi
         replaceEnvVar = replacePrefix dirEnvVarRef "."
-        classPaths' = map (addStartingPathSep . replaceEnvVar) classPaths
+        uriEncodeSpaces = foldl' (\acc c -> acc ++ if c == ' ' then "%20" else [c]) ""
+        classPaths' = map (uriEncodeSpaces . addStartingPathSep . replaceEnvVar) classPaths
         targetManifest = targetDir </> "MANIFEST.MF"
         launcherJar = targetDir </> (exeName ++ ".launcher.jar")
 


### PR DESCRIPTION
Fixes https://github.com/typelead/eta/issues/732
I haven't a easy way to test it, other than check that the code effectively replaces the chars. Maybe @dumptruckman could give it a try to test it in his env.